### PR TITLE
Update dialyzer rules and allow Elixir language

### DIFF
--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerReportParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerReportParser.java
@@ -103,9 +103,16 @@ public class DialyzerReportParser {
         ActiveRule rule = context.activeRules().find(ruleKey);
         if (rule != null) {
 
-          String filePattern = "**/" + FilenameUtils.getName(fileName);
+          String filePattern = "**/" + fileName;
           InputFile inputFile = context.fileSystem().inputFile(
               context.fileSystem().predicates().matchesPathPattern(filePattern));
+
+          if (inputFile == null) {
+            filePattern = "**/" + FilenameUtils.getName(fileName);
+            inputFile = context.fileSystem().inputFile(
+                    context.fileSystem().predicates().matchesPathPattern(filePattern));
+          }
+
           if (inputFile != null) {
             NewIssue issue = getNewIssue(lineNumber, comment, ruleKey, inputFile);
             issue.save();

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerSensor.java
@@ -33,6 +33,8 @@ import org.sonar.plugins.erlang.xml.XmlRuleManager;
  */
 public class DialyzerSensor implements Sensor {
 
+  private static final String ELIXIR_LANGUAGE_KEY = "elixir";
+
   private final XmlRuleManager dialyzerRuleManager;
 
   public DialyzerSensor() {
@@ -47,8 +49,8 @@ public class DialyzerSensor implements Sensor {
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-            .onlyOnLanguage(ErlangLanguage.KEY)
-            .name("Erlang Dialyzer Sensor");
+            .onlyOnLanguages(ErlangLanguage.KEY, ELIXIR_LANGUAGE_KEY)
+            .name("Erlang/Elixir Dialyzer Sensor");
   }
 
   @Override

--- a/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/dialyzer/rules.xml
+++ b/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/dialyzer/rules.xml
@@ -353,7 +353,8 @@
       <![CDATA[opaque_guard]]>
     </description>
     <messages>
-      <message>Guard test ~w~s breaks the opaqueness of its argument</message>
+      <message>Guard test ~w~s breaks the opacity of its argument</message>
+      <message>Guard test ~s ~s ~s contains ~s</message>
     </messages>
   </rule>
   <rule>
@@ -464,6 +465,105 @@
     </description>
     <messages>
       <message>Callback info about the ~w behaviour is not available</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D043</key>
+    <name><![CDATA[map_update]]></name>
+    <internalKey>map_update</internalKey>
+    <description>
+      <![CDATA[map_update]]>
+    </description>
+    <messages>
+      <message>A key of type ~s cannot exist in a map of type ~s</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D044</key>
+    <name><![CDATA[contract_with_opaque]]></name>
+    <internalKey>contract_with_opaque</internalKey>
+    <description>
+      <![CDATA[contract_with_opaque]]>
+    </description>
+    <messages>
+      <message>The specification for ~w:~w/~w has an opaque subtype ~s which is violated by the success typing ~s</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D045</key>
+    <name><![CDATA[missing_range]]></name>
+    <internalKey>missing_range</internalKey>
+    <description>
+      <![CDATA[missing_range]]>
+    </description>
+    <messages>
+      <message>The success typing for ~w:~w/~w implies that the function might also return ~s but the specification return is ~s</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D046</key>
+    <name><![CDATA[opaque_size]]></name>
+    <internalKey>opaque_size</internalKey>
+    <description>
+      <![CDATA[opaque_size]]>
+    </description>
+    <messages>
+      <message>The size ~s breaks the opacity of ~s</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D047</key>
+    <name><![CDATA[opaque_call]]></name>
+    <internalKey>opaque_call</internalKey>
+    <description>
+      <![CDATA[opaque_call]]>
+    </description>
+    <messages>
+      <message>The call ~s:~s~s breaks the opacity of the term ~s :: ~s</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D048</key>
+    <name><![CDATA[callback_not_exported]]></name>
+    <internalKey>callback_not_exported</internalKey>
+    <description>
+      <![CDATA[callback_not_exported]]>
+    </description>
+    <messages>
+      <message>Callback function ~w/~w exists but is not exported (behaviour ~w)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D049</key>
+    <name><![CDATA[unknown_type]]></name>
+    <internalKey>unknown_type</internalKey>
+    <description>
+      <![CDATA[unknown_type]]>
+    </description>
+    <messages>
+      <message>Unknown type ~w:~w/~w</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D050</key>
+    <name><![CDATA[unknown_function]]></name>
+    <internalKey>unknown_function</internalKey>
+    <description>
+      <![CDATA[unknown_function]]>
+    </description>
+    <messages>
+      <message>Unknown function ~w:~w/~w</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>D051</key>
+    <name><![CDATA[unknown_behaviour]]></name>
+    <internalKey>unknown_behaviour</internalKey>
+    <description>
+      <![CDATA[unknown_behaviour]]>
+    </description>
+    <messages>
+      <message>Unknown behaviour ~w</message>
     </messages>
   </rule>
 </rules>

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/dialyzer/DialyzerRuleDefinitionTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/dialyzer/DialyzerRuleDefinitionTest.java
@@ -43,7 +43,7 @@ public class DialyzerRuleDefinitionTest {
 
     List<RulesDefinition.Rule> rules = repository.rules();
 
-    assertThat(rules.size()).isEqualTo(41);
+    assertThat(rules.size()).isEqualTo(50);
   }
 
 }

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/languages/ErlangQualityProfileTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/languages/ErlangQualityProfileTest.java
@@ -39,7 +39,7 @@ public class ErlangQualityProfileTest {
 
     assertThat(profile.language()).isEqualTo("erlang");
     assertThat(profile.name()).isEqualTo("Sonar way");
-    assertThat(profile.rules().size()).isEqualTo(100);
+    assertThat(profile.rules().size()).isEqualTo(109);
   }
 
 }


### PR DESCRIPTION
1. Update the dialyzer rules using the current master branch of erlang/otp
2. Allow the dialyzer sensor to work on Elixir projects
3. Add fallback to the dialyzer sensor when it can't find a file using the path from the report file. This is needed because in Elixir you can have multiple files with the same filename in separate directories.